### PR TITLE
feat: add webmcp tools for ai agent interaction

### DIFF
--- a/blog/2026-02-22-agent-memory-server-homelab.mdx
+++ b/blog/2026-02-22-agent-memory-server-homelab.mdx
@@ -44,7 +44,7 @@ graph LR
     API[agent-memory-api<br/>:8000] --> Redis
     Worker[agent-memory-worker] -->|polls tasks| Redis
     Worker -->|embeddings<br/>nomic-embed-text| Ollama[Ollama<br/>Mac 192.168.x.x<br/>:11434]
-    Worker -->|generation<br/>llama3.2:3b| Ollama
+    Worker -->|generation<br/>qwen2.5:7b| Ollama
     MCP --> Ollama
     API --> Ollama
 
@@ -59,7 +59,7 @@ graph LR
 | Component | Image | Purpose |
 |-----------|-------|---------|
 | Redis Stack | `redis/redis-stack-server:7.4.0-v8` | Vector store + pub/sub + persistence |
-| API Server | `piotrzan/agent-memory-server:0.13.2-custom-v4` | REST API on port 8000 |
+| API Server | `piotrzan/agent-memory-server:0.13.2-custom-v5` | REST API on port 8000 |
 | MCP Server | Same custom image | MCP interface on port 9000 |
 | Task Worker | Same custom image | Async processing (embeddings, NER, topic extraction) |
 
@@ -79,7 +79,7 @@ graph TD
 
     subgraph "Phase 2: Async Worker"
         D -->|docket task| E[worker picks up job]
-        E --> F[Ollama llama3.2:3b]
+        E --> F[Ollama qwen2.5:7b]
         F --> G[topic extraction]
         F --> H[named entity recognition]
         G --> I[enriched Redis record]
@@ -89,7 +89,9 @@ graph TD
 
 Phase 1 is synchronous. nomic-embed-text converts your text into a 768-dimension vector. Redis stores both the vector and the raw text immediately, so you can search for it right away.
 
-Phase 2 runs in the background. The worker pulls async tasks from Redis (using [docket](https://github.com/chrisguidry/docket)), sends text to llama3.2:3b for topic extraction and NER, and writes structured metadata back. This makes future searches more precise; you can filter by topic or entity, not just vector similarity.
+Phase 2 runs in the background. The worker pulls async tasks from Redis (using [docket](https://github.com/chrisguidry/docket)), sends text to qwen2.5:7b for topic extraction and NER, and writes structured metadata back. This makes future searches more precise; you can filter by topic or entity, not just vector similarity.
+
+I started with llama3.2:3b for generation. It works for simple tasks, but the memory compaction worker merges duplicate memories by asking the LLM to produce clean combined text. llama3.2:3b would output meta-commentary instead: "As a memory merging assistant, I will now merge..." rather than the actual merged content. qwen2.5:7b follows structured output instructions reliably. For tasks where the model must produce clean text without editorializing, instruction adherence matters more than model size.
 
 ### Why Not Just Use OpenAI-backed Memory?
 
@@ -100,7 +102,7 @@ Redis Agent Memory Server supports [LiteLLM](https://docs.litellm.ai/), which me
 <InfoCards
   items={[
     { feature: 'Embeddings', cloud: 'OpenAI ada-002 ($0.10/1M tokens)', local: 'Ollama nomic-embed-text (free)' },
-    { feature: 'Generation', cloud: 'GPT-4 for extraction ($30/1M tokens)', local: 'Ollama llama3.2:3b (free)' },
+    { feature: 'Generation', cloud: 'GPT-4 for extraction ($30/1M tokens)', local: 'Ollama qwen2.5:7b (free)' },
     { feature: 'Vector Store', cloud: 'Pinecone/Weaviate (managed)', local: 'Redis Stack RediSearch (self-hosted)' },
     { feature: 'Data Location', cloud: 'Third-party servers', local: 'Your cluster, your PVC' }
   ]}
@@ -123,7 +125,7 @@ Everything below is the actual deployment. If you just wanted the concept, you c
 ### Prerequisites
 
 - **A Kubernetes cluster.** Any distro works: k3s on a single node, kubeadm, Talos, managed. If you don't have one yet, [k3s](https://k3s.io/) gets you there in one command
-- A machine running [Ollama](https://ollama.com/) with `nomic-embed-text` and `llama3.2:3b` pulled. Can be the same node, a spare laptop, a Mac. Needs ~4GB RAM for both models
+- A machine running [Ollama](https://ollama.com/) with `nomic-embed-text` and `qwen2.5:7b` pulled. Can be the same node, a spare laptop, a Mac. Needs ~6GB RAM for both models
 - ~2.3GB cluster RAM at pod limits for the 4 deployments (actual usage is lower)
 - A storage class that supports PVCs (Longhorn, local-path, OpenEBS, anything)
 - Optional: ArgoCD for GitOps sync, or just `kubectl apply`
@@ -218,7 +220,11 @@ env:
   - name: ENABLE_NER
     value: "true"
   - name: GENERATION_MODEL
-    value: ollama/llama3.2:3b    # explicit tag matters!
+    value: ollama/qwen2.5:7b     # used for memory compaction/merging
+  - name: FAST_MODEL
+    value: ollama/qwen2.5:7b     # topic extraction, query optimization
+  - name: SLOW_MODEL
+    value: ollama/qwen2.5:7b     # complex reasoning tasks
   - name: EMBEDDING_MODEL
     value: ollama/nomic-embed-text
   - name: OLLAMA_API_BASE
@@ -317,7 +323,7 @@ git apply mcp-patches.patch
 docker build -f Dockerfile.patched --target standard -t "$IMAGE" .
 ```
 
-The resulting image (`piotrzan/agent-memory-server:0.13.2-custom-v4`) is used by all three application pods. I've submitted a PR upstream to add streamable-http support natively, but until that lands you'll need a custom image.
+The resulting image (`piotrzan/agent-memory-server:0.13.2-custom-v5`) is used by all three application pods. v5 also fixes a hardcoded `gpt-4o-mini` model reference in the memory compaction function that ignored the `GENERATION_MODEL` setting. I've submitted a PR upstream to add streamable-http support natively, but until that lands you'll need a custom image.
 
 ## Connecting MCP Clients
 

--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -12,6 +12,10 @@ const config = {
   organizationName: "Piotr1215",
   projectName: "dca-prep-kit",
 
+  clientModules: [
+    './src/webmcp.js',
+  ],
+
   // Single tailwind plugin
   plugins: [
     ['./plugins/tailwind-plugin.cjs', {}],

--- a/src/webmcp.js
+++ b/src/webmcp.js
@@ -1,0 +1,167 @@
+// WebMCP tools for Cloud Rumble — exposes site data to AI agents via navigator.modelContext
+// Requires Chrome 146+ with chrome://flags/#enable-webmcp-testing
+
+import talks from './data/talks.json';
+import projects from './data/projects.json';
+import blogs from './data/blogs.json';
+import videos from './data/videos.json';
+
+function matches(text, query) {
+  if (!text || !query) return true;
+  return text.toLowerCase().includes(query.toLowerCase());
+}
+
+function matchesAny(fields, query) {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return fields.some(f => {
+    if (!f) return false;
+    if (Array.isArray(f)) return f.some(item => String(item).toLowerCase().includes(q));
+    return String(f).toLowerCase().includes(q);
+  });
+}
+
+function registerTools() {
+  if (!('modelContext' in navigator)) return;
+
+  navigator.modelContext.registerTool({
+    name: "search_talks",
+    description: "Search Piotr's conference talks and workshops by keyword, tag, year, or status. Returns title, conference, date, tags, type, status, and available links (recording, slides, workshop).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search term to match in title, description, conference name, or tags" },
+        status: { type: "string", description: "Filter by status: submitted, accepted, or completed" },
+        type: { type: "string", description: "Filter by type: talk, workshop, or keynote" },
+      },
+    },
+    execute: async ({ query, status, type }) => {
+      let results = talks.filter(t =>
+        matchesAny([t.title, t.description, t.conference, t.tags], query) &&
+        (!status || t.status === status) &&
+        (!type || t.type === type)
+      );
+      const summary = results.map(t => ({
+        title: t.title,
+        conference: t.conference,
+        date: t.date,
+        type: t.type,
+        status: t.status,
+        tags: t.tags,
+        ...(t.recordingUrl && { recordingUrl: t.recordingUrl }),
+        ...(t.slidesUrl && { slidesUrl: t.slidesUrl }),
+        ...(t.workshopUrl && { workshopUrl: t.workshopUrl }),
+        ...(t.conferenceUrl && { conferenceUrl: t.conferenceUrl }),
+      }));
+      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, talks: summary }) }] };
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: "search_projects",
+    description: "Search Piotr's open source projects by name, tag, or category. Returns name, description, GitHub stars, URL, tags, and install command if available.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search term to match in name, description, or tags" },
+        category: { type: "string", description: "Filter by category (e.g. web, container, cli, neovim)" },
+      },
+    },
+    execute: async ({ query, category }) => {
+      let results = projects.filter(p =>
+        matchesAny([p.name, p.description, p.tags], query) &&
+        (!category || matches(p.category, category))
+      );
+      const summary = results.map(p => ({
+        name: p.name,
+        description: p.description,
+        stars: p.stars,
+        url: p.url,
+        tags: p.tags,
+        category: p.category,
+        ...(p.installCommand && { installCommand: p.installCommand }),
+      }));
+      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, projects: summary }) }] };
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: "search_blogs",
+    description: "Search Piotr's blog posts by keyword or category. Returns title, link, date, description, and categories.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search term to match in title, description, or categories" },
+      },
+    },
+    execute: async ({ query }) => {
+      let results = blogs.filter(b =>
+        matchesAny([b.title, b.description, b.categories], query)
+      );
+      const summary = results.map(b => ({
+        title: b.title,
+        link: b.link,
+        date: b.date,
+        description: b.description,
+        categories: b.categories,
+      }));
+      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, blogs: summary }) }] };
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: "search_videos",
+    description: "Search Piotr's YouTube videos by keyword. Returns title, video URL, date, and description.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search term to match in title or description" },
+      },
+    },
+    execute: async ({ query }) => {
+      let results = videos.filter(v =>
+        matchesAny([v.title, v.description], query)
+      );
+      const summary = results.map(v => ({
+        title: v.title,
+        url: `https://www.youtube.com/watch?v=${v.videoId}`,
+        date: v.date,
+        description: v.description,
+      }));
+      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, videos: summary }) }] };
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: "get_site_info",
+    description: "Get an overview of Cloud Rumble: who Piotr is, what content is available, counts of talks/projects/blogs/videos, and navigation links.",
+    inputSchema: { type: "object", properties: {} },
+    execute: async () => {
+      const info = {
+        site: "Cloud Rumble",
+        author: "Piotr Zaniewski",
+        description: "IT certifications, Kubernetes, cloud native, platform engineering. Conference speaker, open source contributor, DevOps engineer at Loft Labs.",
+        content: {
+          talks: talks.length,
+          projects: projects.length,
+          blogs: blogs.length,
+          videos: videos.length,
+        },
+        links: {
+          talks: "/talks",
+          projects: "/projects",
+          blog: "/blog",
+          videos: "/youtube",
+          github: "https://github.com/Piotr1215",
+          youtube: "https://www.youtube.com/channel/UCkWVN7H3JqGtJ5Pv5bvCrAw",
+        },
+        availableTools: ["search_talks", "search_projects", "search_blogs", "search_videos"],
+      };
+      return { content: [{ type: "text", text: JSON.stringify(info) }] };
+    },
+  });
+
+  console.log('[WebMCP] Registered 5 tools: search_talks, search_projects, search_blogs, search_videos, get_site_info');
+}
+
+registerTools();

--- a/src/webmcp.js
+++ b/src/webmcp.js
@@ -1,5 +1,7 @@
-// WebMCP tools for Cloud Rumble — exposes site data to AI agents via navigator.modelContext
-// Requires Chrome 146+ with chrome://flags/#enable-webmcp-testing
+// WebMCP tools for Cloud Rumble — exposes site data to AI agents via the modelContext API
+// Chrome 149+ Origin Trial (no flag for registered domains), or Chrome 146+ behind
+// chrome://flags/#enable-webmcp-testing. navigator.modelContext was deprecated in
+// Chrome 150 in favor of document.modelContext; we prefer the new namespace and fall back.
 
 import talks from './data/talks.json';
 import projects from './data/projects.json';
@@ -22,9 +24,11 @@ function matchesAny(fields, query) {
 }
 
 function registerTools() {
-  if (!('modelContext' in navigator)) return;
+  const mc = (typeof document !== 'undefined' && document.modelContext) ||
+    (typeof navigator !== 'undefined' && navigator.modelContext);
+  if (!mc) return;
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: "search_talks",
     description: "Search Piotr's conference talks and workshops by keyword, tag, year, or status. Returns title, conference, date, tags, type, status, and available links (recording, slides, workshop).",
     inputSchema: {
@@ -35,6 +39,7 @@ function registerTools() {
         type: { type: "string", description: "Filter by type: talk, workshop, or keynote" },
       },
     },
+    annotations: { readOnlyHint: true },
     execute: async ({ query, status, type }) => {
       let results = talks.filter(t =>
         matchesAny([t.title, t.description, t.conference, t.tags], query) &&
@@ -53,11 +58,11 @@ function registerTools() {
         ...(t.workshopUrl && { workshopUrl: t.workshopUrl }),
         ...(t.conferenceUrl && { conferenceUrl: t.conferenceUrl }),
       }));
-      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, talks: summary }) }] };
+      return JSON.stringify({ count: summary.length, talks: summary });
     },
   });
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: "search_projects",
     description: "Search Piotr's open source projects by name, tag, or category. Returns name, description, GitHub stars, URL, tags, and install command if available.",
     inputSchema: {
@@ -67,6 +72,7 @@ function registerTools() {
         category: { type: "string", description: "Filter by category (e.g. web, container, cli, neovim)" },
       },
     },
+    annotations: { readOnlyHint: true },
     execute: async ({ query, category }) => {
       let results = projects.filter(p =>
         matchesAny([p.name, p.description, p.tags], query) &&
@@ -81,11 +87,11 @@ function registerTools() {
         category: p.category,
         ...(p.installCommand && { installCommand: p.installCommand }),
       }));
-      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, projects: summary }) }] };
+      return JSON.stringify({ count: summary.length, projects: summary });
     },
   });
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: "search_blogs",
     description: "Search Piotr's blog posts by keyword or category. Returns title, link, date, description, and categories.",
     inputSchema: {
@@ -94,6 +100,7 @@ function registerTools() {
         query: { type: "string", description: "Search term to match in title, description, or categories" },
       },
     },
+    annotations: { readOnlyHint: true },
     execute: async ({ query }) => {
       let results = blogs.filter(b =>
         matchesAny([b.title, b.description, b.categories], query)
@@ -105,11 +112,11 @@ function registerTools() {
         description: b.description,
         categories: b.categories,
       }));
-      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, blogs: summary }) }] };
+      return JSON.stringify({ count: summary.length, blogs: summary });
     },
   });
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: "search_videos",
     description: "Search Piotr's YouTube videos by keyword. Returns title, video URL, date, and description.",
     inputSchema: {
@@ -118,6 +125,7 @@ function registerTools() {
         query: { type: "string", description: "Search term to match in title or description" },
       },
     },
+    annotations: { readOnlyHint: true },
     execute: async ({ query }) => {
       let results = videos.filter(v =>
         matchesAny([v.title, v.description], query)
@@ -128,14 +136,15 @@ function registerTools() {
         date: v.date,
         description: v.description,
       }));
-      return { content: [{ type: "text", text: JSON.stringify({ count: summary.length, videos: summary }) }] };
+      return JSON.stringify({ count: summary.length, videos: summary });
     },
   });
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: "get_site_info",
     description: "Get an overview of Cloud Rumble: who Piotr is, what content is available, counts of talks/projects/blogs/videos, and navigation links.",
     inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
     execute: async () => {
       const info = {
         site: "Cloud Rumble",
@@ -157,7 +166,7 @@ function registerTools() {
         },
         availableTools: ["search_talks", "search_projects", "search_blogs", "search_videos"],
       };
-      return { content: [{ type: "text", text: JSON.stringify(info) }] };
+      return JSON.stringify(info);
     },
   });
 


### PR DESCRIPTION
## Summary

Adds WebMCP tools so in-browser AI agents (e.g. Claude in Chrome) can query the site's data directly instead of scraping the DOM.

- Exposes site data via the WebMCP `modelContext` API (W3C Community Group draft, Chrome 149 Origin Trial)
- Five read-only tools: `search_talks`, `search_projects`, `search_blogs`, `search_videos`, `get_site_info`
- Loaded as a Docusaurus `clientModule` on every page
- Feature-detected: no-op on browsers without WebMCP support

## API notes (Chrome 150 current)

The API moved since the first draft of this PR (written against the Chrome 146 DevTrial):

- `navigator.modelContext` is deprecated in Chrome 150 in favor of `document.modelContext`. We prefer `document.modelContext` and fall back to `navigator.modelContext`.
- `execute()` now returns a bare string, not an MCP-style `{ content: [...] }` object.
- All five tools set `annotations.readOnlyHint: true` since they only read.

## Not included

Exposing the tools to real visitors needs a [Chrome 149 Origin Trial](https://developer.chrome.com/docs/ai/webmcp) token (a `<meta>` tag or HTTP header for the registered domain). Without it the code is inert for normal users and only runs behind `chrome://flags/#enable-webmcp-testing`. That registration is a follow-up, not part of this PR.

## Test plan

- [x] Enable `chrome://flags/#enable-webmcp-testing` in Chrome Canary
- [x] Open Netlify preview URL
- [x] Check DevTools console for `[WebMCP] Registered 5 tools`
- [ ] Inspect tools with the Model Context Tool Inspector extension
- [ ] Verify each tool returns structured results

## Note

This PR also carries an unrelated edit to `blog/2026-02-22-agent-memory-server-homelab.mdx` (llama3.2:3b to qwen2.5:7b, image custom-v4 to v5).