### PR TITLE
chore: align renovate config with homelab, retire dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,72 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    ":ignoreUnstable"
   ],
-  "platformAutomerge": true,
+  "description": "Renovate configuration for CloudRumble Docusaurus site",
+  "dependencyDashboard": true,
+  "platformAutomerge": false,
+  "timezone": "Europe/Berlin",
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "assignees": [
+    "Piotr1215"
+  ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "chore(deps):",
+  "prCreation": "immediate",
+  "rebaseWhen": "behind-base-branch",
+  "suppressNotifications": [
+    "prIgnoreNotification"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ]
+  },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "description": "Auto-merge all minor and patch updates once the build passes",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Hold back major updates for manual review",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true,
+      "labels": [
+        "major-update",
+        "needs-review"
+      ]
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "semanticCommitType": "ci",
+      "commitMessageTopic": "GitHub Actions"
     }
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/.claude/**"
   ]
 }


### PR DESCRIPTION
## What

Consolidate dependency automation on **Renovate** and retire **Dependabot**.

- Closed 14 open Dependabot security-update PRs (they failed the `build` check) plus stale #674.
- Disabled Dependabot security updates on the repo (`automated-security-fixes`).
- Rewrote `renovate.json` from the deprecated `config:base` to mirror the homelab config.

## Config shape (adapted from homelab to this npm/Docusaurus repo)

Kept: dependency dashboard, Europe/Berlin timezone, labels + assignee, `config:recommended` + `:ignoreUnstable`, semantic commits (`chore(deps):`), automerge of minor/patch, major updates held for dashboard approval, grouped GitHub Actions.

Deviations from a verbatim homelab copy:
- Dropped ArgoCD / Kubernetes / Terraform / Helm package rules (no such managers here).
- `vulnerabilityAlerts` enabled (homelab has it off): Renovate now covers the security bumps Dependabot used to.
- Tests respected on automerge (no `ignoreTests`): the `build` / Netlify check is meaningful for a deployed site.

## Note

Renovate reads config from the default branch, so this takes effect once merged.