### PR TITLE
chore: improve ai/agent discoverability

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -1,11 +1,15 @@
 // @ts-check
 import {themes as prismThemes} from 'prism-react-renderer';
 
+const siteUrl = "https://frosty-babbage-3125a3.netlify.app";
+const siteDescription =
+  "Cloud Rumble by Piotr Zaniewski: IT certification notes and blogs on Kubernetes, cloud native, and platform engineering, plus conference talks and open source projects.";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Cloud Rumble",
   tagline: "IT Certifications learning notes and blogs. Kubernetes and cloud native ramblings",
-  url: "https://frosty-babbage-3125a3.netlify.app",
+  url: siteUrl,
   baseUrl: "/",
   onBrokenLinks: "warn",
   favicon: "img/favicon.svg",
@@ -14,6 +18,34 @@ const config = {
 
   clientModules: [
     './src/webmcp.js',
+  ],
+
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: { type: 'application/ld+json' },
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebSite',
+            name: 'Cloud Rumble',
+            url: siteUrl,
+            description: siteDescription,
+          },
+          {
+            '@type': 'Person',
+            name: 'Piotr Zaniewski',
+            url: 'https://github.com/Piotr1215',
+            jobTitle: 'DevOps Engineer',
+            sameAs: [
+              'https://github.com/Piotr1215',
+              'https://www.youtube.com/channel/UCkWVN7H3JqGtJ5Pv5bvCrAw',
+            ],
+          },
+        ],
+      }),
+    },
   ],
 
   // Single tailwind plugin
@@ -57,6 +89,10 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        { name: "description", content: siteDescription },
+        { property: "og:description", content: siteDescription },
+      ],
       algolia: {
         appId: "YVUCIOP9V7",
         apiKey: "ca28f15cd304fda34283080362ddefc6",

--- a/static/.well-known/webmcp
+++ b/static/.well-known/webmcp
@@ -1,0 +1,13 @@
+{
+  "name": "Cloud Rumble",
+  "description": "Site tools for querying Piotr Zaniewski's talks, projects, blog posts, and videos.",
+  "registration": "imperative",
+  "api": "navigator/document.modelContext",
+  "tools": [
+    { "name": "search_talks", "description": "Search conference talks and workshops by keyword, status, or type." },
+    { "name": "search_projects", "description": "Search open source projects by name, tag, or category." },
+    { "name": "search_blogs", "description": "Search blog posts by keyword or category." },
+    { "name": "search_videos", "description": "Search YouTube videos by keyword." },
+    { "name": "get_site_info", "description": "Overview of the site, content counts, and navigation links." }
+  ]
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,20 @@
+# Cloud Rumble
+
+> Cloud Rumble is Piotr Zaniewski's site for IT certification notes and blogs on Kubernetes, cloud native, and platform engineering, alongside conference talks and open source projects.
+
+Piotr Zaniewski is a DevOps engineer, conference speaker, and open source contributor. The site collects long-form blog posts, a catalog of talks and workshops, open source projects, and YouTube videos.
+
+This site also exposes WebMCP tools (navigator/document.modelContext) so in-browser AI agents can query talks, projects, blogs, and videos directly.
+
+## Sections
+
+- [Blog](https://frosty-babbage-3125a3.netlify.app/blog): technical posts on Kubernetes, cloud native, platform engineering, and certifications
+- [Talks](https://frosty-babbage-3125a3.netlify.app/talks): conference talks and workshops, with recordings and slides where available
+- [Projects](https://frosty-babbage-3125a3.netlify.app/projects): open source projects with descriptions and GitHub links
+- [Videos](https://frosty-babbage-3125a3.netlify.app/youtube): YouTube videos
+
+## Links
+
+- GitHub: https://github.com/Piotr1215
+- YouTube: https://www.youtube.com/channel/UCkWVN7H3JqGtJ5Pv5bvCrAw
+- Sitemap: https://frosty-babbage-3125a3.netlify.app/sitemap.xml

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,28 @@
+# Cloud Rumble — crawler policy
+# AI crawlers and assistants are explicitly welcome.
+
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+Sitemap: https://frosty-babbage-3125a3.netlify.app/sitemap.xml


### PR DESCRIPTION
## What

Follow-up to the WebMCP tools PR (#620). The WebMCP Inspector audit scored the site low because, beyond the runtime WebMCP tools, it exposed almost none of the static signals AI agents and crawlers look for. This adds them.

| Audit item | Fix |
|---|---|
| Meta description: missing | Global `themeConfig.metadata` description + `og:description` (homepage had none) |
| Schema.org JSON-LD: 0 blocks | `headTags` JSON-LD: `WebSite` + `Person` |
| robots.txt (AI bots): missing | `static/robots.txt`, permissive, names GPTBot / ClaudeBot / Google-Extended / PerplexityBot / OAI-SearchBot, links the sitemap |
| /llms.txt: 404 | `static/llms.txt` site summary with section links |
| /.well-known/webmcp: 404 | `static/.well-known/webmcp` manifest describing the five imperative tools |

## Not addressed (by design)

- **window.ai (Gemini Nano): not found** is a client-side Chrome capability (Built-in AI flag), nothing the site can set.
- **Declarative WebMCP attributes** (`toolname` / `tooldescription` / `toolaction`) are an alternative to the imperative API we already use in #620. Adding them would duplicate the tool surface, so skipped.

Expected audit movement: 6/15 to ~11/15.

## Verification

`npm run build` succeeds; confirmed in `build/`: meta description + `og:description` rendered on the homepage, JSON-LD `WebSite`/`Person` present, and `robots.txt` / `llms.txt` / `.well-known/webmcp` all served at the site root.

## Note

`robots.txt` is permissive (no `Disallow`) on purpose so crawlers can still reach pages. The `Sitemap:` and JSON-LD URLs use the configured site URL; adjust if a custom production domain is in use.