### PR TITLE
ci: auto-clear upcoming flag on past talks

### DIFF
--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -30,6 +30,10 @@ jobs:
         continue-on-error: true
         run: node scripts/update-youtube-videos.js
 
+      - name: Update talk statuses
+        continue-on-error: true
+        run: node scripts/update-talks-status.js
+
       - name: Update Medium blogs
         id: medium
         continue-on-error: true
@@ -81,8 +85,8 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git checkout -b "$BRANCH_NAME"
-          git add src/data/projects.json src/data/videos.json src/data/blogs.json
-          git commit -m "chore: update GitHub stars, YouTube videos, and Medium blogs"
+          git add src/data/projects.json src/data/videos.json src/data/blogs.json src/data/talks.json
+          git commit -m "chore: update GitHub stars, YouTube videos, Medium blogs, and talk statuses"
           git push -u origin "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
@@ -92,7 +96,7 @@ jobs:
           GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           gh pr create \
-            --title "chore: update GitHub stars, YouTube videos, and Medium blogs" \
+            --title "chore: update GitHub stars, YouTube videos, Medium blogs, and talk statuses" \
             --body "Automated data update from scheduled workflow" \
             --base master \
             --head "${{ env.BRANCH_NAME }}"

--- a/scripts/update-talks-status.js
+++ b/scripts/update-talks-status.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+/**
+ * Mark past talks as done by clearing the `upcoming` flag in talks.json.
+ *
+ * A talk is "upcoming" while its date is today or in the future. Once the
+ * date passes, the talk should drop out of the upcoming section on the site.
+ * This mirrors the upcoming rule in scripts/sync-talks.sh, but edits
+ * talks.json in place instead of regenerating it from DuckDB (the DuckDB
+ * source has drifted, so a full regen would drop real talks).
+ *
+ * Usage: node scripts/update-talks-status.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TALKS_FILE = path.join(__dirname, '../src/data/talks.json');
+
+/**
+ * Decide whether a talk date is today or in the future.
+ * Supports full dates (YYYY-MM-DD) and month-only dates (YYYY-MM).
+ * Anything else (null, empty, unparseable) is treated as not upcoming.
+ */
+function isUpcoming(date, now) {
+  if (typeof date !== 'string') return false;
+
+  if (date.length === 10) {
+    return date >= now.toISOString().slice(0, 10); // YYYY-MM-DD
+  }
+  if (date.length === 7) {
+    return date >= now.toISOString().slice(0, 7); // YYYY-MM
+  }
+  return false;
+}
+
+function main() {
+  const raw = fs.readFileSync(TALKS_FILE, 'utf8');
+  const talks = JSON.parse(raw);
+  const now = new Date();
+
+  let changed = 0;
+  for (const talk of talks) {
+    // Only clear the flag for talks that have already happened. Never set it,
+    // so a talk is never surfaced as upcoming by automation.
+    if (talk.upcoming === true && !isUpcoming(talk.date, now)) {
+      talk.upcoming = false;
+      changed++;
+      console.log(`Marked past: ${talk.date} - ${talk.title}`);
+    }
+  }
+
+  if (changed === 0) {
+    console.log('No talks to update.');
+    return;
+  }
+
+  // Preserve the existing on-disk format: one talk object per line, no
+  // indentation, no trailing newline. Keeps diffs minimal.
+  const out = '[' + talks.map((t) => JSON.stringify(t)).join(',\n') + ']';
+  fs.writeFileSync(TALKS_FILE, out, 'utf8');
+  console.log(`✓ Updated ${changed} talk(s) in ${TALKS_FILE}`);
+}
+
+main();


### PR DESCRIPTION
## What

Extends the daily data cron (`update-stars.yml`) to keep talk statuses current. A new step runs `scripts/update-talks-status.js`, which clears the `upcoming` flag on any talk whose date has passed.

## Why

The `upcoming` flag was only ever updated by hand, or by `sync-talks.sh`, which can't be run safely: its DuckDB source has drifted from `talks.json` and a full regen would drop real talks. So past talks lingered in the site's upcoming section until someone remembered to edit the JSON.

## How

- `scripts/update-talks-status.js` reuses the same date rule as `sync-talks.sh` (length-aware for `YYYY-MM-DD` and `YYYY-MM`; null dates ignored).
- One-directional: only clears `upcoming`, never sets it, so automation never surfaces a talk prematurely.
- Edits `talks.json` in place (one object per line) so it never touches the drifted DuckDB source.
- The existing `git diff src/data/` check folds `talks.json` into the same auto-merge PR as stars/videos/blogs.

## Notes

`status` is intentionally left untouched: in the UI it only hides `submitted` talks and renders no badge, so clearing `upcoming` is all that moves a talk out of the upcoming section. Today's run is a no-op (the only upcoming talk is dated 2026-07-09). Verified the flip and date edge cases against simulated past talks.