### PR TITLE
fix: upgrade swiper to 12.1.2 (CVE-2026-27212)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-type-animation": "^3.2.0",
         "react-youtube": "10.1.0",
         "stream-browserify": "^3.0.0",
-        "swiper": "^12.0.0"
+        "swiper": "^12.1.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.9.1",
@@ -20899,9 +20899,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.0.3.tgz",
-      "integrity": "sha512-BHd6U1VPEIksrXlyXjMmRWO0onmdNPaTAFduzqR3pgjvi7KfmUCAm/0cj49u2D7B0zNjMw02TSeXfinC1hDCXg==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
+      "integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-type-animation": "^3.2.0",
     "react-youtube": "10.1.0",
     "stream-browserify": "^3.0.0",
-    "swiper": "^12.0.0"
+    "swiper": "^12.1.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.1",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -56,7 +56,7 @@
   {
     "name": "presenterm.nvim",
     "description": "Neovim plugin for presenterm",
-    "stars": 39,
+    "stars": 40,
     "url": "https://github.com/Piotr1215/presenterm.nvim",
     "tags": [
       "Neovim",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11856,
+    "stars": 11857,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11854,
+    "stars": 11856,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11218,
+    "stars": 11220,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11874,
+    "stars": 11878,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11857,
+    "stars": 11860,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11220,
+    "stars": 11225,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",
@@ -296,7 +296,7 @@
   {
     "name": "Pepr",
     "description": "Type safe K8s middleware for humans. A Kubernetes controller framework that simplifies building admission controllers, operators, and other K8s automation with TypeScript.",
-    "stars": 230,
+    "stars": 231,
     "url": "https://github.com/defenseunicorns/pepr",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11234,
+    "stars": 11236,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11860,
+    "stars": 11864,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11225,
+    "stars": 11229,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -230,7 +230,7 @@
   {
     "name": "homelab",
     "description": "GitOps-managed Kubernetes homelab. ArgoCD, Cilium, MetalLB, and various self-hosted services.",
-    "stars": 13,
+    "stars": 14,
     "url": "https://github.com/Piotr1215/homelab",
     "tags": [
       "Kubernetes",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11869,
+    "stars": 11874,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11231,
+    "stars": 11232,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11878,
+    "stars": 11881,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11232,
+    "stars": 11234,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11864,
+    "stars": 11867,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11229,
+    "stars": 11231,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11851,
+    "stars": 11852,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11220,
+    "stars": 11218,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11852,
+    "stars": 11854,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11867,
+    "stars": 11869,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -149,7 +149,7 @@
   {
     "name": "cv-pipeline-template",
     "description": "Automated CV generation pipeline that creates multiple psychologically-optimized CV variants from YAML data. Uses LaTeX, GitHub Actions, and color psychology research.",
-    "stars": 16,
+    "stars": 17,
     "url": "https://github.com/Piotr1215/cv-pipeline-template",
     "tags": [
       "Automation",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11884,
+    "stars": 11886,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11242,
+    "stars": 11243,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -41,7 +41,7 @@
   {
     "name": "pairup.nvim",
     "description": "AI Pair Programming in Neovim",
-    "stars": 54,
+    "stars": 53,
     "url": "https://github.com/Piotr1215/pairup.nvim",
     "tags": [
       "Neovim",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11909,
+    "stars": 11913,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11253,
+    "stars": 11257,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11916,
+    "stars": 11918,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11908,
+    "stars": 11909,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11249,
+    "stars": 11253,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11891,
+    "stars": 11894,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11245,
+    "stars": 11244,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11913,
+    "stars": 11916,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11257,
+    "stars": 11256,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -70,7 +70,7 @@
   {
     "name": "dotfiles",
     "description": "Pop_OS! dotfiles with install script. Complete development environment setup with Neovim, Tmux, and essential CLI tools.",
-    "stars": 134,
+    "stars": 133,
     "url": "https://github.com/Piotr1215/dotfiles",
     "tags": [
       "Dotfiles",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11888,
+    "stars": 11891,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11243,
+    "stars": 11245,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",
@@ -309,7 +309,7 @@
   {
     "name": "vCluster Docs",
     "description": "Documentation for vCluster - virtual Kubernetes clusters",
-    "stars": 9,
+    "stars": 10,
     "url": "https://github.com/loft-sh/vcluster-docs",
     "tags": [
       "Documentation",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11900,
+    "stars": 11908,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11245,
+    "stars": 11249,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11895,
+    "stars": 11898,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11881,
+    "stars": 11880,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11236,
+    "stars": 11238,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11898,
+    "stars": 11900,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11242,
+    "stars": 11245,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -70,7 +70,7 @@
   {
     "name": "dotfiles",
     "description": "Pop_OS! dotfiles with install script. Complete development environment setup with Neovim, Tmux, and essential CLI tools.",
-    "stars": 133,
+    "stars": 134,
     "url": "https://github.com/Piotr1215/dotfiles",
     "tags": [
       "Dotfiles",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11893,
+    "stars": 11895,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11245,
+    "stars": 11243,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11918,
+    "stars": 11920,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11256,
+    "stars": 11257,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -41,7 +41,7 @@
   {
     "name": "pairup.nvim",
     "description": "AI Pair Programming in Neovim",
-    "stars": 53,
+    "stars": 54,
     "url": "https://github.com/Piotr1215/pairup.nvim",
     "tags": [
       "Neovim",
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11894,
+    "stars": 11893,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11244,
+    "stars": 11245,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",
@@ -309,7 +309,7 @@
   {
     "name": "vCluster Docs",
     "description": "Documentation for vCluster - virtual Kubernetes clusters",
-    "stars": 10,
+    "stars": 11,
     "url": "https://github.com/loft-sh/vcluster-docs",
     "tags": [
       "Documentation",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11880,
+    "stars": 11884,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11238,
+    "stars": 11242,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",
@@ -283,7 +283,7 @@
   {
     "name": "OpenGitOps Documents",
     "description": "Lasting documents from the OpenGitOps project which are versioned and released together, including the GitOps Principles and Glossary. Defining standards and best practices for GitOps.",
-    "stars": 481,
+    "stars": 482,
     "url": "https://github.com/open-gitops/documents",
     "tags": [
       "GitOps",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -270,7 +270,7 @@
   {
     "name": "vCluster",
     "description": "vCluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces.",
-    "stars": 11243,
+    "stars": 11242,
     "url": "https://github.com/loft-sh/vcluster",
     "tags": [
       "Kubernetes",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -256,7 +256,7 @@
   {
     "name": "Crossplane",
     "description": "A control plane framework for platform engineering. Build custom control planes to manage cloud native software with custom Kubernetes APIs and abstractions - without writing controllers. Unlocks the power of Kubernetes custom resources with a rich ecosystem of extensions.",
-    "stars": 11886,
+    "stars": 11888,
     "url": "https://github.com/crossplane/crossplane",
     "tags": [
       "Kubernetes",
@@ -296,7 +296,7 @@
   {
     "name": "Pepr",
     "description": "Type safe K8s middleware for humans. A Kubernetes controller framework that simplifies building admission controllers, operators, and other K8s automation with TypeScript.",
-    "stars": 231,
+    "stars": 232,
     "url": "https://github.com/defenseunicorns/pepr",
     "tags": [
       "Kubernetes",


### PR DESCRIPTION
## Summary
Upgrade swiper from 12.0.3 to 12.1.2 to fix CVE-2026-27212.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-27212 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-27212` |
| **File** | `package-lock.json` (dependency: `swiper`) |
| **Assessment** | Likely exploitable |

**Description**: Prototype pollution in swiper

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-27212` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
